### PR TITLE
chore(phase-0a): SSR 化と scrollBehavior 導入によるブログ機能基盤整備

### DIFF
--- a/frontend/app/router.options.ts
+++ b/frontend/app/router.options.ts
@@ -1,0 +1,26 @@
+import type { RouterConfig } from '@nuxt/schema'
+
+/**
+ * Nuxt の router オプション。
+ *
+ * vue-scrollto から vue-router の scrollBehavior へ移行するための設定。
+ * hash リンク (/#about など) 到達時のスクロール先オフセットは
+ * CSS の scroll-margin-top: var(--header-height) 側で担保しているため、
+ * ここでは top オフセット指定を行わない。
+ */
+export default <RouterConfig>{
+  scrollBehavior(to, from, savedPosition) {
+    if (savedPosition) {
+      return savedPosition
+    }
+
+    if (to.hash) {
+      return {
+        el: to.hash,
+        behavior: 'smooth',
+      }
+    }
+
+    return { top: 0 }
+  },
+}

--- a/frontend/assets/scss/_size.scss
+++ b/frontend/assets/scss/_size.scss
@@ -1,1 +1,2 @@
 $item-size: 350px;
+$header-height: 50px;

--- a/frontend/assets/scss/app.scss
+++ b/frontend/assets/scss/app.scss
@@ -13,6 +13,16 @@ html {
   scroll-behavior: smooth;
 }
 
+// hash リンク (#about, #service, #works, #contact) でスクロールした際に
+// 固定ヘッダにかぶらないよう、ビューポート上端からのオフセットを確保する。
+// ページ側 scoped style ではセクタ指定が効かないケースがあるためグローバルに置く。
+#about,
+#service,
+#works,
+#contact {
+  scroll-margin-top: var(--header-height);
+}
+
 body {
   height: 100%;
   margin: 0 auto;

--- a/frontend/assets/scss/app.scss
+++ b/frontend/assets/scss/app.scss
@@ -13,6 +13,14 @@ html {
   scroll-behavior: smooth;
 }
 
+// OS / ブラウザで「視差効果を減らす」設定をしているユーザには、
+// スムーススクロールの代わりに即時ジャンプ（auto）を提供してアクセシビリティを確保する。
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 // hash リンク (#about, #service, #works, #contact) でスクロールした際に
 // 固定ヘッダにかぶらないよう、ビューポート上端からのオフセットを確保する。
 // ページ側 scoped style ではセクタ指定が効かないケースがあるためグローバルに置く。

--- a/frontend/assets/scss/app.scss
+++ b/frontend/assets/scss/app.scss
@@ -4,8 +4,13 @@
 @use "color";
 @use "size";
 
+:root {
+  --header-height: #{size.$header-height};
+}
+
 html {
   font-family: 'Noto Sans JP', sans-serif;
+  scroll-behavior: smooth;
 }
 
 body {

--- a/frontend/components/TheHeader.vue
+++ b/frontend/components/TheHeader.vue
@@ -3,16 +3,16 @@
     <div class="actions parallax-bg" :class="{ hide: !hideScrollingActions }">
       <div class="left" />
       <div class="center">
-        <nuxt-link v-scroll-to="'#about'" class="actions-link mr-1" to>
+        <nuxt-link to="/#about" class="actions-link mr-1">
           About
         </nuxt-link>
-        <nuxt-link v-scroll-to="'#service'" class="actions-link mr-1" to>
+        <nuxt-link to="/#service" class="actions-link mr-1">
           Service
         </nuxt-link>
-        <nuxt-link v-scroll-to="'#works'" class="actions-link mr-1" to>
+        <nuxt-link to="/#works" class="actions-link mr-1">
           Works
         </nuxt-link>
-        <nuxt-link v-scroll-to="'#contact'" class="actions-link mr-1" to>
+        <nuxt-link to="/#contact" class="actions-link mr-1">
           Contact
         </nuxt-link>
         <anchor link="https://labo.nozomi.bike" :shine="false" class="actions-link">

--- a/frontend/components/TheHeader.vue
+++ b/frontend/components/TheHeader.vue
@@ -42,9 +42,12 @@
 <script setup lang="ts">
 import Anchor from "~/components/atoms/Anchor.vue";
 import {FontAwesomeIcon} from "@fortawesome/vue-fontawesome";
+import {
+  HEADER_SCROLL_CHECK_FPS,
+  HEADER_SHRINK_THRESHOLD_PX,
+  MILLISECONDS_PER_SECOND,
+} from "~/constants/timing";
 
-const FPS60 = ref<number>(60)
-const SCROLL_TOP_POSITION = ref<number>(5)
 const currentScrollY = ref<number>(0)
 
 const setCurrentScrollPositionY = () => {
@@ -54,16 +57,26 @@ const setCurrentScrollPositionY = () => {
 const hideScrollingActions = ref<boolean>(true)
 
 const setHideScrollingActions = () => {
-  hideScrollingActions.value = currentScrollY.value <= SCROLL_TOP_POSITION.value
+  hideScrollingActions.value = currentScrollY.value <= HEADER_SHRINK_THRESHOLD_PX
 }
+
+let scrollCheckIntervalId: ReturnType<typeof setInterval> | null = null
 
 onMounted(() => {
   setCurrentScrollPositionY()
   document.addEventListener('scroll', setCurrentScrollPositionY)
 
-  setInterval(() => {
+  scrollCheckIntervalId = setInterval(() => {
     setHideScrollingActions()
-  }, 1000 / FPS60.value)
+  }, MILLISECONDS_PER_SECOND / HEADER_SCROLL_CHECK_FPS)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('scroll', setCurrentScrollPositionY)
+  if (scrollCheckIntervalId !== null) {
+    clearInterval(scrollCheckIntervalId)
+    scrollCheckIntervalId = null
+  }
 })
 </script>
 

--- a/frontend/components/atoms/Anchor.vue
+++ b/frontend/components/atoms/Anchor.vue
@@ -12,7 +12,10 @@
 </template>
 
 <script setup lang="ts">
-import { ANCHOR_ACTIVATION_INTERVAL_MS } from "~/constants/timing";
+import {
+  ANCHOR_ACTIVATION_INTERVAL_MS,
+  ANCHOR_SHINE_ACTIVE_DURATION_MS,
+} from "~/constants/timing";
 
 const props = withDefaults(defineProps<{
   link: string,
@@ -27,11 +30,20 @@ const isActive = computed((): boolean => {
   return !props.shine ? false : active.value
 })
 
+let shineResetTimeoutId: ReturnType<typeof setTimeout> | null = null
+
 watch(active, (value) => {
+  // watch 再発火時には前回の timeout をクリアしてから新規発行することで、
+  // 古い値での多重発火（先行する false 書き換え）を防止する。
+  if (shineResetTimeoutId !== null) {
+    clearTimeout(shineResetTimeoutId)
+    shineResetTimeoutId = null
+  }
   if (value) {
-    setTimeout(() => {
+    shineResetTimeoutId = setTimeout(() => {
       active.value = false
-    }, 500)
+      shineResetTimeoutId = null
+    }, ANCHOR_SHINE_ACTIVE_DURATION_MS)
   }
 })
 
@@ -47,6 +59,10 @@ onBeforeUnmount(() => {
   if (activationIntervalId !== null) {
     clearInterval(activationIntervalId)
     activationIntervalId = null
+  }
+  if (shineResetTimeoutId !== null) {
+    clearTimeout(shineResetTimeoutId)
+    shineResetTimeoutId = null
   }
 })
 </script>

--- a/frontend/components/atoms/Anchor.vue
+++ b/frontend/components/atoms/Anchor.vue
@@ -12,6 +12,8 @@
 </template>
 
 <script setup lang="ts">
+import { ANCHOR_ACTIVATION_INTERVAL_MS } from "~/constants/timing";
+
 const props = withDefaults(defineProps<{
   link: string,
   shine?: boolean
@@ -33,10 +35,19 @@ watch(active, (value) => {
   }
 })
 
+let activationIntervalId: ReturnType<typeof setInterval> | null = null
+
 onMounted(() => {
-  setInterval(() => {
+  activationIntervalId = setInterval(() => {
     active.value = true
-  }, 3000)
+  }, ANCHOR_ACTIVATION_INTERVAL_MS)
+})
+
+onBeforeUnmount(() => {
+  if (activationIntervalId !== null) {
+    clearInterval(activationIntervalId)
+    activationIntervalId = null
+  }
 })
 </script>
 

--- a/frontend/constants/timing.ts
+++ b/frontend/constants/timing.ts
@@ -1,0 +1,30 @@
+/**
+ * タイミング系マジックナンバーを集約した定数モジュール。
+ *
+ * UI アニメーション・スクロール監視・再描画スケジューリングなどで利用する
+ * 時間（ミリ秒）や閾値（ピクセル）、サンプリングレート（FPS）を定義する。
+ */
+
+/** ヘッダの「上部に居るか」判定に使う scrollY の閾値（px） */
+export const HEADER_SHRINK_THRESHOLD_PX = 5
+
+/** スクロール状態を評価するサンプリングレート（frames per second） */
+export const HEADER_SCROLL_CHECK_FPS = 60
+
+/** 1秒をミリ秒に変換する際の基準値 */
+export const MILLISECONDS_PER_SECOND = 1000
+
+/** Anchor コンポーネントの shine アニメーション再起動間隔（ms） */
+export const ANCHOR_ACTIVATION_INTERVAL_MS = 3000
+
+/** プロフィールメッセージの下線描画を開始するまでの初回遅延（ms） */
+export const UNDERLINE_DRAW_INITIAL_DELAY_MS = 1000
+
+/** 下線描画を次の行に進めるまでのステップ遅延（ms） */
+export const UNDERLINE_DRAW_STEP_DELAY_MS = 2000
+
+/** 下線描画サイクル全体を再実行する周期（ms） */
+export const UNDERLINE_REDRAW_INTERVAL_MS = 15000
+
+/** contact セクションのアクティブ状態を再評価する周期（ms） */
+export const CONTACT_ACTIVE_CHECK_INTERVAL_MS = 1500

--- a/frontend/constants/timing.ts
+++ b/frontend/constants/timing.ts
@@ -17,6 +17,9 @@ export const MILLISECONDS_PER_SECOND = 1000
 /** Anchor コンポーネントの shine アニメーション再起動間隔（ms） */
 export const ANCHOR_ACTIVATION_INTERVAL_MS = 3000
 
+/** Anchor の active 状態を自動解除するまでの持続時間（ms） */
+export const ANCHOR_SHINE_ACTIVE_DURATION_MS = 500
+
 /** プロフィールメッセージの下線描画を開始するまでの初回遅延（ms） */
 export const UNDERLINE_DRAW_INITIAL_DELAY_MS = 1000
 

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -1,5 +1,9 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
+  // SSG (prerender) を有効化するため、SSR を明示的に true に設定する。
+  // Nuxt 3 のデフォルトは true だが、設計 v4 の 6.3 節に従って明示する。
+  ssr: true,
+
   css: [
     '@/assets/scss/app.scss',
     '@fortawesome/fontawesome-svg-core/styles.css',

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -1,7 +1,5 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  ssr: false,
-
   css: [
     '@/assets/scss/app.scss',
     '@fortawesome/fontawesome-svg-core/styles.css',

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,8 +12,7 @@
         "@fortawesome/vue-fontawesome": "^3.0.2",
         "material-icons": "^1.13.1",
         "nuxt": "^3.19.0",
-        "sass": "^1.57.1",
-        "vue-scrollto": "^2.20.0"
+        "sass": "^1.57.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4272,13 +4271,6 @@
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
-    },
-    "node_modules/bezier-easing": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz",
-      "integrity": "sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/bindings": {
       "version": "1.5.0",
@@ -11278,16 +11270,6 @@
       },
       "peerDependencies": {
         "vue": "^3.5.0"
-      }
-    },
-    "node_modules/vue-scrollto": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/vue-scrollto/-/vue-scrollto-2.20.0.tgz",
-      "integrity": "sha512-7i+AGKJTThZnMEkhIPgrZjyAX+fXV7/rGdg+CV283uZZwCxwiMXaBLTmIc5RTA4uwGnT+E6eJle3mXQfM2OD3A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bezier-easing": "2.1.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,6 @@
     "@fortawesome/vue-fontawesome": "^3.0.2",
     "material-icons": "^1.13.1",
     "nuxt": "^3.19.0",
-    "sass": "^1.57.1",
-    "vue-scrollto": "^2.20.0"
+    "sass": "^1.57.1"
   }
 }

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -381,4 +381,13 @@ onBeforeUnmount(() => {
 .trend {
   color: color.$red;
 }
+
+// hash リンク (#about, #service, #works, #contact) でスクロールした際に
+// 固定ヘッダにかぶらないよう、ビューポート上端からのオフセットを確保する。
+#about,
+#service,
+#works,
+#contact {
+  scroll-margin-top: var(--header-height);
+}
 </style>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -221,12 +221,23 @@ const active2 = ref<boolean>(false)
 const active3 = ref<boolean>(false)
 const contactActive = ref<boolean>(false)
 
+const pendingTimeoutIds = new Set<ReturnType<typeof setTimeout>>()
+
+const scheduleTimeout = (fn: () => void, ms: number): ReturnType<typeof setTimeout> => {
+  const id = setTimeout(() => {
+    pendingTimeoutIds.delete(id)
+    fn()
+  }, ms)
+  pendingTimeoutIds.add(id)
+  return id
+}
+
 const runDrawUnderLine = () => {
-  setTimeout(() => {
+  scheduleTimeout(() => {
     active1.value = true
-    setTimeout(() => {
+    scheduleTimeout(() => {
       active2.value = true
-      setTimeout(() => {
+      scheduleTimeout(() => {
         active3.value = true
       }, UNDERLINE_DRAW_STEP_DELAY_MS)
     }, UNDERLINE_DRAW_STEP_DELAY_MS)
@@ -270,6 +281,8 @@ onBeforeUnmount(() => {
     clearInterval(contactActiveCheckIntervalId)
     contactActiveCheckIntervalId = null
   }
+  pendingTimeoutIds.forEach(clearTimeout)
+  pendingTimeoutIds.clear()
 })
 </script>
 

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -394,13 +394,4 @@ onBeforeUnmount(() => {
 .trend {
   color: color.$red;
 }
-
-// hash リンク (#about, #service, #works, #contact) でスクロールした際に
-// 固定ヘッダにかぶらないよう、ビューポート上端からのオフセットを確保する。
-#about,
-#service,
-#works,
-#contact {
-  scroll-margin-top: var(--header-height);
-}
 </style>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -203,6 +203,12 @@ import ProfileImages from '~/components/parts/ProfileImages'
 import Service from '~/components/parts/Service'
 import Work from '~/components/parts/Work'
 import {FontAwesomeIcon} from "@fortawesome/vue-fontawesome";
+import {
+  CONTACT_ACTIVE_CHECK_INTERVAL_MS,
+  UNDERLINE_DRAW_INITIAL_DELAY_MS,
+  UNDERLINE_DRAW_STEP_DELAY_MS,
+  UNDERLINE_REDRAW_INTERVAL_MS,
+} from "~/constants/timing";
 
 const currentScrollY = ref<number>(0)
 
@@ -222,9 +228,9 @@ const runDrawUnderLine = () => {
       active2.value = true
       setTimeout(() => {
         active3.value = true
-      }, 2000)
-    }, 2000)
-  }, 1000)
+      }, UNDERLINE_DRAW_STEP_DELAY_MS)
+    }, UNDERLINE_DRAW_STEP_DELAY_MS)
+  }, UNDERLINE_DRAW_INITIAL_DELAY_MS)
 }
 
 const resetUnderLine = () => {
@@ -237,18 +243,33 @@ const setContactActive = () => {
   contactActive.value = currentScrollY.value >= document.body.scrollHeight - window.innerHeight
 }
 
+let underlineRedrawIntervalId: ReturnType<typeof setInterval> | null = null
+let contactActiveCheckIntervalId: ReturnType<typeof setInterval> | null = null
+
 onMounted(() => {
   setCurrentScrollPositionY()
   document.addEventListener('scroll', setCurrentScrollPositionY)
 
   runDrawUnderLine()
-  setInterval(() => {
+  underlineRedrawIntervalId = setInterval(() => {
     resetUnderLine()
     runDrawUnderLine()
-  }, 15000)
-  setInterval(() => {
+  }, UNDERLINE_REDRAW_INTERVAL_MS)
+  contactActiveCheckIntervalId = setInterval(() => {
     setContactActive()
-  }, 1500)
+  }, CONTACT_ACTIVE_CHECK_INTERVAL_MS)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('scroll', setCurrentScrollPositionY)
+  if (underlineRedrawIntervalId !== null) {
+    clearInterval(underlineRedrawIntervalId)
+    underlineRedrawIntervalId = null
+  }
+  if (contactActiveCheckIntervalId !== null) {
+    clearInterval(contactActiveCheckIntervalId)
+    contactActiveCheckIntervalId = null
+  }
 })
 </script>
 

--- a/frontend/plugins/vue-scrollto.ts
+++ b/frontend/plugins/vue-scrollto.ts
@@ -1,9 +1,0 @@
-import { defineNuxtPlugin } from "#app"
-import VueScrollTo from 'vue-scrollto'
-
-export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.vueApp.use(VueScrollTo, {
-    duration: 700,
-    offset: -50
-  })
-})


### PR DESCRIPTION
## Summary

ブログ機能追加プロジェクトのフェーズ 0a。後続フェーズ（0b: deploy.yml 整理 / 0c: package.json 最小変更 / 1: MVP ブログ ...）の基盤として、Nuxt 3 の SSG prerender 有効化と既存 SPA 向けコードの SSR 互換性確保を行う。

- **関連 Issue**: なし（本 PR は設計合意済みの PR 分割方針に基づく実装第一弾）

## Changes

- **SSR 化（SSG prerender 用）**
  - `ssr: false` を削除し `ssr: true` を明示
  - 既存 3 ページ（`/`, `/privacy_policy`, `/terms`）を `nuxt generate` で静的 HTML としてプリレンダー
  - 本番配信経路（rsync + nginx 静的配信）はそのまま
- **`vue-scrollto` 撤去と `scrollBehavior` 移行**
  - `app/router.options.ts` 新設、`scrollBehavior` で `savedPosition` / hash / トップ遷移を制御
  - `TheHeader.vue` の `v-scroll-to` を `<NuxtLink to="/#...">` に置換（4 箇所）
  - `vue-scrollto` プラグイン削除、`package.json` 依存削除
- **メモリリーク修正（`onBeforeUnmount` で全クリーンアップ）**
  - `TheHeader.vue`: `setInterval` + `scroll` リスナ
  - `Anchor.vue`: `setInterval` + `watch` 内の `setTimeout`
  - `pages/index.vue`: 2 本の `setInterval` + `scroll` リスナ + `runDrawUnderLine` 内のネスト `setTimeout`
- **マジックナンバー定数化**
  - `constants/timing.ts` 新設、全タイマー関連数値を名前付き定数化
- **ハッシュリンクのヘッダかぶり対策**
  - CSS 変数 `--header-height` を `:root` に追加
  - `scroll-margin-top` を `app.scss` グローバルで `#about / #service / #works / #contact` に付与
  - `html { scroll-behavior: smooth }` + `@media (prefers-reduced-motion: reduce)` で無効化（アクセシビリティ対応）

## Checklist

- [x] `npm run generate` が成功、`.output/public/` に既存 3 ページの HTML が生成される
- [x] ビルドログに hydration warning / console error 0
- [x] `vue-scrollto` / `v-scroll-to` のコード参照が 0（`app/router.options.ts` の由来説明コメント除く）
- [x] CLAUDE.md 規約遵守（マジックナンバー禁止、1 コミット 1 論理変更、Conventional Commits）
- [x] コードレビュー（code-reviewer）承認、セキュリティレビュー（security-engineer）承認
- [ ] ランタイムでの手動確認（`npm run dev` で hydration warning 0、`/#about` 等のスムーズスクロール、ブラウザ戻るで scroll 位置復元、メモリリーク非発生）← team leader 最終確認

## その他

- **設計根拠**: 設計 v4 承認済み（Critical 11 件全件解消確認）。フェーズ 0a は設計 8 節 / 6.3 / 6.4 節 / 7.1 節に対応
- **PR 分割方針**: 設計 v4 冒頭の「PR 分割方針」章に従い、フェーズごとに PR を分割。本 PR がマージされたら `nonz250/phase-0b-*` で次フェーズに着手
- **後続フェーズへの申し送り**:
  - フェーズ 0b: `deploy.yml` から `npm run build` を削除し `npm run generate` 単独化、rsync パスの検証（V-1/V-2/V-8）
  - フェーズ 0c: Playwright 導入・Vitest 導入・`cross-env` 追加、`dev` / `generate` スクリプトの環境変数切替
  - フェーズ 1: `@nuxt/content` 導入、`articles/*.md` 読み込み、MVP ブログ公開、下書き多層防御、dev プレビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)