### PR TITLE
ci(phase-0b): deploy.yml 整理と GitHub Actions バージョン昇格

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,10 +16,10 @@ jobs:
         working-directory: frontend
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '22.x'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Install Dependencies
         run: |
           npm ci
-          npm run build
           npm run generate
 
       - name: Deploy Directories


### PR DESCRIPTION
## Summary

ブログ機能追加プロジェクトのフェーズ 0b。`.github/workflows/deploy.yml` を整理し、GitHub Actions が Node 16 ランナー廃止でも安定動作する状態にする。

- **関連 Issue**: なし（設計 v4 PR 分割方針に従うフェーズ分割の一環）

## Changes

- **`npm run build` を削除**し `npm run generate` 単独化
  - `nuxt generate` が `.output/public/` に最終成果物を出すため、`nuxt build` は重複実行で CI 時間の浪費になっていた
  - フェーズ 0a で `ssr: true` を明示したことにより、`generate` のみで SSG が成立する
- **GitHub Actions バージョン昇格**
  - `actions/checkout@v3` → `@v4`
  - `actions/setup-node@v1` → `@v4`
  - いずれも旧バージョンは Node 16 runner 依存で GitHub が deprecation 警告を出すもの。v4 系は Node 20 で動作
- **rsync 設定は変更なし**
  - `.github/rsync_include.txt` (`/.output/`) と `.github/rsync_exclude.txt` (`/*`) は `.output/public/` 配下のみを転送する現行設定のままで整合
  - V-1 / V-2（`@nuxt/content` 導入後の画像経路検証）はフェーズ 1 で対応

## Checklist

- [x] `deploy.yml` の `npm run build` が削除されている
- [x] `actions/checkout` / `actions/setup-node` が v4 系に揃っている
- [x] rsync 転送対象（`/.output/`）の整合性を維持
- [ ] main マージ後、自動 deploy が成功することを確認（team leader）

## その他

- **設計根拠**: 設計 v4 PR 分割方針「フェーズ 0b」、設計 6.5 節 `deploy.yml` 変更点
- **後続**: フェーズ 0c（`package.json` の `vue-scrollto` 相当は 0a で除去済、0c では `cross-env` 追加 + `vitest`/`playwright` 追加 + `dev`/`generate` スクリプトに `CONTENT_PREVIEW` 切替）
- **Dependabot アラート**: 本 PR スコープ外。main ブランチに残存する依存脆弱性は別トラックで対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)