### PR TITLE
fix(og): og:url を末尾スラッシュ付きに揃える

### DIFF
--- a/frontend/pages/articles/[...slug].vue
+++ b/frontend/pages/articles/[...slug].vue
@@ -80,7 +80,10 @@ const description: string =
 // fallback に倒すガードが `resolveArticleOgImagePath` 内に入っている。
 const runtimeConfig = useRuntimeConfig()
 const baseUrl: string = runtimeConfig.public.baseUrl
-const canonicalUrl: string = `${baseUrl}/articles/${slug}`
+// 末尾スラッシュ付きに揃える。nginx 側で `/articles/<slug>` → `/articles/<slug>/`
+// に 301 リダイレクトされるため、og:url が redirect 元のままだと SNS クローラが
+// canonical 不一致でカード表示を失敗することがある。redirect 後の URL に寄せる。
+const canonicalUrl: string = `${baseUrl}/articles/${slug}/`
 const ogImageUrl: string = `${baseUrl}${resolveArticleOgImagePath(slug)}`
 
 useHead({


### PR DESCRIPTION
## Summary

本番 nginx は `/articles/<slug>` を `/articles/<slug>/` に 301 リダイレクトします。一方、記事詳細の `og:url` は末尾スラッシュなしで出力されており、SNS クローラーが canonical 不一致と判定してカード表示を失敗することがあります。

## Change

`pages/articles/[...slug].vue` の `canonicalUrl` を末尾スラッシュ付きに変更。

```diff
- const canonicalUrl: string = `${baseUrl}/articles/${slug}`
+ const canonicalUrl: string = `${baseUrl}/articles/${slug}/`
```

## 検証

- `NO_NETWORK_FETCH=1 npm run generate` 成功
- `.output/public/articles/hello/index.html` の `og:url`:
  `<meta property="og:url" content="https://nozomi.bike/articles/hello/">`

## マージ後

本番デプロイ後、SNS キャッシュ更新が必要:
- Twitter / X: [Card Validator](https://cards.x.com/validator) で URL を再投入
- Facebook / Slack: [Sharing Debugger](https://developers.facebook.com/tools/debug/) で "Scrape Again"
- Discord: 1 日程度でキャッシュ失効

🤖 Generated with [Claude Code](https://claude.com/claude-code)