### PR TITLE
fix(content): use Zenn-supported published_at format

### DIFF
--- a/articles/nonz250-ai-rotom.md
+++ b/articles/nonz250-ai-rotom.md
@@ -4,7 +4,7 @@ emoji: "🤖"
 type: "tech"
 topics: ["ai", "mcp", "typescript", "pokemon"]
 published: true
-published_at: '2026-04-19 16:00'
+published_at: '2026-04-19 21:00'
 ---
 
 こんにちは。nonz250 です。皆さんはポケモンバトルをやっていますか？

--- a/articles/nonz250-ai-rotom.md
+++ b/articles/nonz250-ai-rotom.md
@@ -4,7 +4,7 @@ emoji: "🤖"
 type: "tech"
 topics: ["ai", "mcp", "typescript", "pokemon"]
 published: true
-published_at: '2026-04-19T16:00:00+09:00'
+published_at: '2026-04-19 16:00'
 ---
 
 こんにちは。nonz250 です。皆さんはポケモンバトルをやっていますか？


### PR DESCRIPTION
## Summary
- `articles/nonz250-ai-rotom.md` の `published_at` が ISO 8601 形式 (`2026-04-19T16:00:00+09:00`) になっており、Zenn CLI の FrontMatter 解析に失敗していた。
- Zenn が要求する `YYYY-MM-DD hh:mm` 形式 (`2026-04-19 16:00`) に修正。

## Test plan
- [ ] main マージ後、Zenn 連携でエラーが出ないこと
- [ ] 公開日時が JST 2026-04-19 16:00 として反映されること

https://claude.ai/code/session_01KyCENLFEzMVQvD6aY5rSBk