### PR TITLE
fix(ci): remove paths-ignore conflicting with paths in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,8 +42,11 @@ on:
   push:
     branches:
       - main
-    # v4 パイプライン自身が articles/ と public/ を commit する。両 path は
-    # paths-ignore に入れて push トリガーから除外し、自己ループを防ぐ。
+    # GitHub Actions は同一 event に paths と paths-ignore を併記できない
+    # (workflow file issue で run 自体が起動不能になる)。paths は allowlist
+    # として機能し、ここに列挙されていない articles/ と public/ への push は
+    # 自動的に除外される。これにより auto-commit job の再 push による自己
+    # ループを防ぐ。
     paths:
       - 'site-articles/**'
       - 'scripts/**'
@@ -51,9 +54,6 @@ on:
       - '.github/workflows/publish.yml'
       - 'package.json'
       - 'package-lock.json'
-    paths-ignore:
-      - 'articles/**'
-      - 'public/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

#50 merge 後の main push で起動した \`publish.yml\` (run [24711636980](https://github.com/nonz250/homepage/actions/runs/24711636980)) が **0 秒で \`workflow file issue\`** として失敗していました。display name が workflow の \`name\` ではなく \`.github/workflows/publish.yml\` (ファイルパス) にフォールバックしていたことから、YAML 解釈段階で GitHub Actions がトリガー宣言を受け付けなかったと判断しました。

原因は \`on.push\` に **\`paths\` と \`paths-ignore\` を併記** していたことです。GitHub Actions は同一 event にこの 2 キーを同時指定するとエラー扱いし、workflow run 自体を起動しません。

## Changes

- \`.github/workflows/publish.yml\` から \`paths-ignore\` ブロックを削除
- \`paths\` は allowlist として動作するため、ここに列挙されていない \`articles/\` と \`public/\` への push (auto-commit job が再 push する対象) は自動的にトリガーから除外されます
- 自己ループ防止は \`paths\` の allowlist 機構で担保されることをコメントに明記

## Checklist

- [x] publish.yml の他セクション (job 定義、SHA pin、fork ガード、concurrency、permissions) は無変更
- [x] articles/ と public/ は paths に含まれないため、auto-commit 由来の push では publish.yml は起動しない
- [ ] merge 後の main push で publish.yml が正しく起動すること (runs list で確認)
- [ ] 4 job (generate → qiita-publish → auto-commit → deploy) が直列実行されること

## その他

- \`name: Publish articles\` が UI 上で正しく表示されることで parse 成功を判定する想定
- QIITA_TOKEN / SSH_PRIVATE_KEY 等の secret 設定は本 PR スコープ外。未設定なら qiita-publish / deploy job が該当 step で失敗するため、merge 前に secret 設定を確認してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>