### PR TITLE
style(articles): 記事内 Markdown テーブルのスタイルを追加する

### DIFF
--- a/frontend/pages/articles/[...slug].vue
+++ b/frontend/pages/articles/[...slug].vue
@@ -170,5 +170,39 @@ useSeoMeta({
     max-width: 100%;
     height: auto;
   }
+
+  // GFM テーブル (`| col | col |`) の見た目。Markdown パイプラインは
+  // 変更せず、記事本文内で出力される素の `<table>` に対してスタイルを
+  // 当てるだけに留めている。本文幅を超える場合は横スクロールする。
+  :deep(table) {
+    display: block;
+    width: max-content;
+    max-width: 100%;
+    margin: 1.5rem 0;
+    overflow-x: auto;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+    line-height: 1.6;
+  }
+
+  :deep(thead) {
+    background-color: rgba(0, 0, 0, 0.04);
+  }
+
+  :deep(tbody tr:nth-child(even)) {
+    background-color: rgba(0, 0, 0, 0.02);
+  }
+
+  :deep(th),
+  :deep(td) {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    vertical-align: top;
+    text-align: left;
+  }
+
+  :deep(th) {
+    font-weight: 600;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary

close https://github.com/nonz250/homepage/issues/55

記事本文の Markdown テーブル (`| col | col |`) がブラウザデフォルト描画になっており、罫線・ヘッダ強調・セル余白が不足していた。`frontend/pages/articles/[...slug].vue` の scoped `<style>` に `.body :deep(table/thead/tbody tr:nth-child(even)/th/td)` のスタイルを追加し、記事本文として読みやすい見た目に整える。

## Changes

* `frontend/pages/articles/[...slug].vue` の `<style scoped lang=\"scss\">` 内 `.body` ブロックに以下を追加:
  * `:deep(table)` に `display: block; width: max-content; max-width: 100%; overflow-x: auto; border-collapse: collapse; margin: 1.5rem 0;` を指定し、狭幅でも横スクロールで閲覧可能にする
  * `:deep(thead)` / `:deep(tbody tr:nth-child(even))` に淡い背景色を指定してヘッダ強調と行ストライプを付与
  * `:deep(th), :deep(td)` に `padding: 0.5rem 0.75rem;`、`border: 1px solid rgba(0, 0, 0, 0.12);`、`vertical-align: top;`、`text-align: left;` を指定
  * `:deep(th)` に `font-weight: 600;` を指定

## Scope

* 対象: 記事本文内の `<table>` 系要素の**見た目のみ**
* 対象外: Markdown パイプライン (remark/rehype)、`content.config.ts`、`components/content/` 配下、テーブル以外のスタイル

## Checklist

- [x] 既存のテーブルレンダリング結果と崩れの再現箇所を特定（`site-articles/2026-04-19-ai-rotom-tech.md`）
- [x] スタイル修正の実装
- [x] `npm run test:unit` / `test:integration` / `test:contract` 全パス（667 件）
- [x] `npm run build` が成功、コンパイル後 CSS に `.body[data-v-*] table { border-collapse: collapse; ... }` が出力されていることを確認
- [ ] ライト/ダーク両テーマ・PC/モバイル幅での視認確認（プレビュー環境で要レビュー）

## その他

* 本プロジェクトには OS 連動のダークモード実装が無いため、色は半透明黒 (`rgba(0, 0, 0, *)`) で指定し、ブラウザが `color-scheme` を自動適用した際にも破綻しにくい値にしてある。正式なダーク対応は別 Issue のスコープとする。
* 横スクロール領域のキーボードアクセシビリティ (`tabindex=\"0\"` ラッパー付与) は rehype 側変更が必要になるため本 PR のスコープ外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)