### PR TITLE
fix(frontend): 記事ページの Markdown ヘディングデザインを修正

### DIFF
--- a/frontend/assets/scss/_typography.scss
+++ b/frontend/assets/scss/_typography.scss
@@ -1,0 +1,32 @@
+// 記事本文 (Markdown) ヘディングのタイポグラフィスケール。
+// h2 -> h6 にかけて段階的にサイズと上マージンを縮小し、視覚的な階層感を作る。
+// マジックナンバー回避と、将来テーマ調整時の一括変更を目的に集約する。
+
+// デスクトップ (>=601px)
+$article-heading-font-size-h2: 1.6rem;
+$article-heading-font-size-h3: 1.3rem;
+$article-heading-font-size-h4: 1.1rem;
+$article-heading-font-size-h5: 1rem;
+$article-heading-font-size-h6: 0.95rem;
+
+// モバイル (<=600px) は 0.9 倍前後に縮小して可読性を確保する。
+$article-heading-font-size-mobile-h2: 1.4rem;
+$article-heading-font-size-mobile-h3: 1.2rem;
+$article-heading-font-size-mobile-h4: 1.05rem;
+$article-heading-font-size-mobile-h5: 0.95rem;
+$article-heading-font-size-mobile-h6: 0.9rem;
+
+// 上マージン: 直前要素 (本文/リスト/コードブロック) との縦リズムを作るために
+// 段階的に小さくする。下マージンは line-height で吸収するため小さめ。
+$article-heading-margin-top-h2: 2.5rem;
+$article-heading-margin-top-h3: 2rem;
+$article-heading-margin-top-h4: 1.75rem;
+$article-heading-margin-top-h5: 1.5rem;
+$article-heading-margin-top-h6: 1.25rem;
+
+$article-heading-margin-bottom: 0.75rem;
+$article-heading-line-height: 1.4;
+
+// h2 のみ下線を引いて章区切りを強調する。色は本文と同じく低彩度で抑える。
+$article-heading-h2-border-color: rgba(0, 0, 0, 0.08);
+$article-heading-h2-padding-bottom: 0.3rem;

--- a/frontend/pages/articles/[...slug].vue
+++ b/frontend/pages/articles/[...slug].vue
@@ -113,6 +113,7 @@ useSeoMeta({
 
 <style scoped lang="scss">
 @use "assets/scss/color";
+@use "assets/scss/typography";
 
 .article-detail {
   padding-bottom: 3rem;
@@ -132,16 +133,70 @@ useSeoMeta({
   line-height: 1.8;
   color: color.$black;
 
+  // Markdown ヘディング (h2〜h6) の共通設定。
+  // ID アンカーで遷移した際、固定ヘッダの下に隠れないよう scroll-margin-top を確保する。
+  :deep(h2),
+  :deep(h3),
+  :deep(h4),
+  :deep(h5),
+  :deep(h6) {
+    margin-bottom: typography.$article-heading-margin-bottom;
+    line-height: typography.$article-heading-line-height;
+    font-weight: bold;
+    color: color.$black;
+    scroll-margin-top: var(--header-height);
+  }
+
   :deep(h2) {
-    margin-top: 2rem;
-    padding-bottom: 0.3rem;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
-    font-size: 1.4rem;
+    margin-top: typography.$article-heading-margin-top-h2;
+    padding-bottom: typography.$article-heading-h2-padding-bottom;
+    border-bottom: 1px solid typography.$article-heading-h2-border-color;
+    font-size: typography.$article-heading-font-size-h2;
   }
 
   :deep(h3) {
-    margin-top: 1.5rem;
-    font-size: 1.15rem;
+    margin-top: typography.$article-heading-margin-top-h3;
+    font-size: typography.$article-heading-font-size-h3;
+  }
+
+  :deep(h4) {
+    margin-top: typography.$article-heading-margin-top-h4;
+    font-size: typography.$article-heading-font-size-h4;
+  }
+
+  :deep(h5) {
+    margin-top: typography.$article-heading-margin-top-h5;
+    font-size: typography.$article-heading-font-size-h5;
+    color: color.$lnk-black;
+  }
+
+  :deep(h6) {
+    margin-top: typography.$article-heading-margin-top-h6;
+    font-size: typography.$article-heading-font-size-h6;
+    color: color.$lnk-black;
+  }
+
+  // モバイル幅では各ヘディングをやや縮小し、画面占有を抑えつつ階層感は保つ。
+  @media screen and (max-width: 600px) {
+    :deep(h2) {
+      font-size: typography.$article-heading-font-size-mobile-h2;
+    }
+
+    :deep(h3) {
+      font-size: typography.$article-heading-font-size-mobile-h3;
+    }
+
+    :deep(h4) {
+      font-size: typography.$article-heading-font-size-mobile-h4;
+    }
+
+    :deep(h5) {
+      font-size: typography.$article-heading-font-size-mobile-h5;
+    }
+
+    :deep(h6) {
+      font-size: typography.$article-heading-font-size-mobile-h6;
+    }
   }
 
   :deep(p) {


### PR DESCRIPTION
## Summary

close https://github.com/nonz250/homepage/issues/56

記事本文内 Markdown ヘディング (`<h1>`〜`<h6>`) のデザイン崩れを修正し、
階層感・縦リズム・モバイル可読性を整えた。機能 (Markdown → HTML 変換、
アンカーリンク、目次生成) はそのままで、見た目のみの変更に留めている。

## Changes

* `frontend/assets/scss/_typography.scss` を新規追加し、記事本文ヘディング用のサイズ・マージン定数を集約 (マジックナンバー回避)
* `frontend/pages/articles/[...slug].vue` の scoped style を更新
  * `:deep(h2)` / `:deep(h3)` のサイズ・マージンを再調整して階層感を強化
  * 未定義だった `:deep(h4)` / `:deep(h5)` / `:deep(h6)` のスタイルを追加
  * 全ヘディング共通で `scroll-margin-top: var(--header-height)` を付与し、アンカージャンプ時に固定ヘッダに隠れないよう改善
  * モバイル幅 (`max-width: 600px`) 用の縮小サイズを追加

## Scope (変更しないもの)

* 見出しアンカー生成ロジック (rehype-slug)
* 目次 (ToC) 生成ロジック (`ArticleToc.vue`, `flattenTocLinks`)
* Markdown パーサ設定
* ヘディング以外の要素の見た目

## Checklist

- [x] 既存の unit test 全件グリーン (582 tests)
- [x] `nuxt build` が成功
- [x] 見出しアンカー (`#id`) の生成ロジックは変更なし
- [x] 目次 (ToC) ロジックは変更なし
- [ ] 実機 (PC / モバイル) で視認確認

## その他

issue の Plan コメントに記載した設計方針 (h2: 1.6rem, h3: 1.3rem, h4: 1.1rem, h5: 1rem, h6: 0.95rem / 上マージン 2.5→1.25rem の段階) に沿って実装。

🤖 Generated with [Claude Code](https://claude.com/claude-code)