### PR TITLE
fix(prerender): TZ ナシ published_at を JST として解釈し記事 404 を解消

### DIFF
--- a/frontend/tests/unit/article/parsePublishedAt.test.ts
+++ b/frontend/tests/unit/article/parsePublishedAt.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { parsePublishedAtMs } from '../../../utils/article/parsePublishedAt'
+
+/**
+ * `parsePublishedAtMs` の単体テスト。
+ *
+ * 仕様の核心:
+ *   - Zenn Legacy 形式 (`YYYY-MM-DD HH:mm`) は **常に JST (UTC+9) として
+ *     解釈** する。CI (UTC) と JST のホストで判定がブレないこと。
+ *   - ISO 8601 with offset / `Z` 付きはホスト TZ に左右されず、表記通りの
+ *     絶対時刻として解釈する。
+ *   - 不正値は `NaN` を返す (`Date.parse` 互換)。
+ *
+ * Issue #59 (記事直リン 404) のリグレッション防止が主目的。Zenn Legacy
+ * 形式を CI の UTC で評価して未来扱いし、prerender から記事が消える事故を
+ * 二度と起こさないよう絶対時刻でテストを固定する。
+ */
+describe('parsePublishedAtMs', () => {
+  describe('Zenn Legacy format (YYYY-MM-DD HH:mm) — interpreted as JST', () => {
+    it('parses 21:00 JST as 12:00 UTC of the same day', () => {
+      // 2026-04-23 21:00 JST = 2026-04-23T12:00:00Z
+      const expected = Date.parse('2026-04-23T12:00:00Z')
+      expect(parsePublishedAtMs('2026-04-23 21:00')).toBe(expected)
+    })
+
+    it('parses 00:00 JST as previous day 15:00 UTC', () => {
+      // 2026-04-24 00:00 JST = 2026-04-23T15:00:00Z
+      const expected = Date.parse('2026-04-23T15:00:00Z')
+      expect(parsePublishedAtMs('2026-04-24 00:00')).toBe(expected)
+    })
+
+    it('parses 09:00 JST as 00:00 UTC of the same day', () => {
+      const expected = Date.parse('2026-04-23T00:00:00Z')
+      expect(parsePublishedAtMs('2026-04-23 09:00')).toBe(expected)
+    })
+  })
+
+  describe('ISO 8601 with offset', () => {
+    it('parses +09:00 offset as JST', () => {
+      const expected = Date.parse('2026-04-23T12:00:00Z')
+      expect(parsePublishedAtMs('2026-04-23T21:00:00+09:00')).toBe(expected)
+    })
+
+    it('parses negative offset', () => {
+      const expected = Date.parse('2026-04-23T20:00:00Z')
+      expect(parsePublishedAtMs('2026-04-23T15:00:00-05:00')).toBe(expected)
+    })
+  })
+
+  describe('ISO 8601 UTC (Z suffix)', () => {
+    it('parses Z as UTC', () => {
+      const expected = Date.parse('2026-04-23T12:00:00Z')
+      expect(parsePublishedAtMs('2026-04-23T12:00:00Z')).toBe(expected)
+    })
+  })
+
+  describe('invalid input', () => {
+    it('returns NaN for an unparseable string', () => {
+      expect(Number.isNaN(parsePublishedAtMs('not-a-date'))).toBe(true)
+    })
+
+    it('returns NaN for an empty string', () => {
+      expect(Number.isNaN(parsePublishedAtMs(''))).toBe(true)
+    })
+  })
+})

--- a/frontend/tests/unit/prerender/buildPrerenderRoutes.test.ts
+++ b/frontend/tests/unit/prerender/buildPrerenderRoutes.test.ts
@@ -188,4 +188,43 @@ describe('buildPrerenderRoutes', () => {
       expect(result).toEqual(['/articles/a', '/articles/b', '/articles/c'])
     })
   })
+
+  /**
+   * Issue #59 リグレッション: Zenn Legacy 形式 (`YYYY-MM-DD HH:mm`) は TZ
+   * 情報を持たないため、CI の UTC 環境で `Date.parse` をそのまま使うと
+   * 21:00 JST が 21:00 UTC として未来扱いされ、記事が prerender 対象から
+   * 漏れて URL が 404 になる事故が発生した。`parsePublishedAtMs` 経由で
+   * 必ず JST として解釈されることを絶対時刻で固定する。
+   */
+  describe('Zenn Legacy published_at (issue #59 regression)', () => {
+    const ZENN_LEGACY_BUILD_TIME = new Date('2026-04-23T13:00:00Z')
+
+    it('treats "YYYY-MM-DD HH:mm" as JST so a 21:00 JST article published before a 13:00 UTC build is visible', () => {
+      // 2026-04-23 21:00 JST = 2026-04-23 12:00 UTC < 13:00 UTC build
+      const article: Article = {
+        slug: 'jst-zenn-legacy',
+        published: true,
+        published_at: '2026-04-23 21:00',
+      }
+      const result = buildPrerenderRoutes([article], ZENN_LEGACY_BUILD_TIME, {
+        preview: false,
+        nodeEnv: 'production',
+      })
+      expect(result).toEqual(['/articles/jst-zenn-legacy'])
+    })
+
+    it('still excludes a future Zenn Legacy datetime once interpreted as JST', () => {
+      // 2099-01-01 09:00 JST is in the far future regardless of TZ.
+      const article: Article = {
+        slug: 'future',
+        published: true,
+        published_at: '2099-01-01 09:00',
+      }
+      const result = buildPrerenderRoutes([article], ZENN_LEGACY_BUILD_TIME, {
+        preview: false,
+        nodeEnv: 'production',
+      })
+      expect(result).toEqual([])
+    })
+  })
 })

--- a/frontend/tests/unit/prerender/buildTagsIndex.test.ts
+++ b/frontend/tests/unit/prerender/buildTagsIndex.test.ts
@@ -272,4 +272,28 @@ describe('buildTagsIndex', () => {
       expect(result).toEqual({ 'boundary-tag': ['boundary'] })
     })
   })
+
+  /**
+   * Issue #59 リグレッション: prerender 側と完全に同じ TZ 解釈
+   * (Zenn Legacy 形式は JST) でタグ index も組まないと「個別ページは prerender
+   * されているのにタグページからリンクされない」逆向きの不整合が発生する。
+   */
+  describe('Zenn Legacy published_at (issue #59 regression)', () => {
+    const ZENN_LEGACY_BUILD_TIME = new Date('2026-04-23T13:00:00Z')
+
+    it('treats "YYYY-MM-DD HH:mm" as JST so a 21:00 JST article is included before a 13:00 UTC build', () => {
+      // 2026-04-23 21:00 JST = 12:00 UTC < 13:00 UTC build
+      const article: TagIndexArticle = {
+        slug: 'jst-zenn-legacy',
+        topics: ['ai'],
+        published: true,
+        published_at: '2026-04-23 21:00',
+      }
+      const result = buildTagsIndex([article], ZENN_LEGACY_BUILD_TIME, {
+        preview: false,
+        nodeEnv: 'production',
+      })
+      expect(result).toEqual({ ai: ['jst-zenn-legacy'] })
+    })
+  })
 })

--- a/frontend/utils/article/parsePublishedAt.ts
+++ b/frontend/utils/article/parsePublishedAt.ts
@@ -1,0 +1,52 @@
+/**
+ * `published_at` 文字列を Unix epoch ミリ秒に変換する純関数。
+ *
+ * frontmatter の `published_at` は schema (`scripts/lib/schema/publishedAt.ts`)
+ * 上 3 形式を受理する:
+ *
+ *   1. `YYYY-MM-DD HH:mm`               — Zenn Connect 現行フォーマット (TZ なし)
+ *   2. `YYYY-MM-DDTHH:mm:ss±HH:mm`      — ISO 8601 with numeric offset
+ *   3. `YYYY-MM-DDTHH:mm:ssZ`           — ISO 8601 UTC
+ *
+ * 1. の Zenn Legacy フォーマットには TZ 情報が含まれない。`Date.parse` の
+ * 挙動はホスト OS のタイムゾーンに依存し、CI (GitHub Actions ubuntu-latest =
+ * UTC) では「21:00 UTC」として解釈されるため、ビルド時刻と比較した予約投稿
+ * 判定 (`buildPrerenderRoutes` / `buildTagsIndex`) で記事が誤って除外され、
+ * `/articles/<slug>/` が 404 になる事故を起こした。
+ *
+ * Zenn Connect 自体が日本のサービスでありデフォルトを JST として運用して
+ * いるため、本ヘルパーも TZ なし入力は **JST (UTC+9) として解釈** する。
+ * ISO 8601 with offset / `Z` 付きは表記通りの絶対時刻として扱う。
+ *
+ * 戻り値:
+ *   - 解釈に成功: Unix epoch ミリ秒 (number)
+ *   - 解釈に失敗: `NaN` (`Date.parse` の挙動を踏襲し、呼び出し側の
+ *     `Number.isNaN` 分岐をそのまま再利用できるようにする)
+ */
+
+/**
+ * Zenn Connect 互換の TZ 無し datetime 形式 (`YYYY-MM-DD HH:mm`)。
+ *
+ * scripts 側の `PUBLISHED_AT_ZENN_LEGACY_PATTERN` と同等。schema は scripts/
+ * 側に集約されているが、frontend からの import は別経路 (vitest 設定 / Nuxt
+ * alias の制約) で簡単に共有できないため、ここでも独立に持つ。仕様変更時は
+ * 両ファイルを同期する。
+ */
+export const PUBLISHED_AT_ZENN_LEGACY_PATTERN =
+  /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]) ([01]\d|2[0-3]):[0-5]\d$/
+
+/** Zenn Legacy 形式に補う JST オフセット表記 */
+const JST_OFFSET_SUFFIX = '+09:00'
+
+/**
+ * `published_at` 文字列を Unix epoch ミリ秒に変換する。
+ *
+ * @param value `published_at` の生文字列 (schema 受理済み想定)
+ * @returns 解釈成功時は ms、失敗時は `NaN`
+ */
+export function parsePublishedAtMs(value: string): number {
+  if (PUBLISHED_AT_ZENN_LEGACY_PATTERN.test(value)) {
+    return Date.parse(`${value.replace(' ', 'T')}:00${JST_OFFSET_SUFFIX}`)
+  }
+  return Date.parse(value)
+}

--- a/frontend/utils/prerender/buildPrerenderRoutes.ts
+++ b/frontend/utils/prerender/buildPrerenderRoutes.ts
@@ -11,6 +11,8 @@
  *   throw して build を失敗させ、誤設定の本番デプロイを水際で止める。
  */
 
+import { parsePublishedAtMs } from '../article/parsePublishedAt'
+
 /** preview 状態を本番で検出した際に送出するエラーメッセージ */
 export const PREVIEW_IN_PRODUCTION_ERROR_MESSAGE =
   'preview mode is not allowed in production build'
@@ -53,9 +55,9 @@ export interface BuildPrerenderRoutesOpts {
  *   2. `preview === true` なら全 articles のルートを返す
  *   3. `preview === false` なら以下の条件を満たす記事のみ:
  *      - `published === true`
- *      - かつ `published_at` が未指定、または `Date.parse(published_at)` が
- *        `buildTime` 以下 (予約投稿で未来日時のものは除外)
- *   4. `Date.parse` が NaN を返す不正な日時文字列は除外 (published_at は
+ *      - かつ `published_at` が未指定、または `parsePublishedAtMs(published_at)`
+ *        が `buildTime` 以下 (予約投稿で未来日時のものは除外)
+ *   4. `parsePublishedAtMs` が NaN を返す不正な日時文字列は除外 (published_at は
  *      schema レイヤで検証しているが、純関数として堅牢にふるまう)
  *
  * @param articles 評価対象の記事リスト (readonly)
@@ -88,7 +90,12 @@ export function buildPrerenderRoutes(
  * - `published === false` の下書きは常に false
  * - `published_at` 未指定は「公開扱い・予約なし」とみなす
  * - `published_at` が valid な日時で `buildTime` 以下なら true
- * - `Date.parse` が NaN (不正な文字列) なら false
+ * - `parsePublishedAtMs` が NaN (不正な文字列) なら false
+ *
+ * 日時パースは `parsePublishedAtMs` に委譲する。Zenn Legacy 形式
+ * (`YYYY-MM-DD HH:mm`) は TZ 情報を持たないため、CI (UTC) と JST 環境で
+ * 解釈が割れて予約投稿の判定がズレる事故を避ける目的で、ヘルパ側で
+ * 明示的に JST として正規化している。
  */
 function isVisibleAtBuildTime(article: Article, buildTimeMs: number): boolean {
   if (!article.published) {
@@ -97,7 +104,7 @@ function isVisibleAtBuildTime(article: Article, buildTimeMs: number): boolean {
   if (article.published_at === undefined) {
     return true
   }
-  const publishedAtMs = Date.parse(article.published_at)
+  const publishedAtMs = parsePublishedAtMs(article.published_at)
   if (Number.isNaN(publishedAtMs)) {
     return false
   }

--- a/frontend/utils/prerender/buildTagsIndex.ts
+++ b/frontend/utils/prerender/buildTagsIndex.ts
@@ -21,6 +21,7 @@
  *   と `buildTime` を注入し、返り値は `Record<tag, slug[]>`。
  */
 import { PREVIEW_IN_PRODUCTION_ERROR_MESSAGE } from './buildPrerenderRoutes'
+import { parsePublishedAtMs } from '../article/parsePublishedAt'
 
 /** production ビルドを識別する NODE_ENV の値 */
 const NODE_ENV_PRODUCTION = 'production'
@@ -59,7 +60,7 @@ export interface BuildTagsIndexOpts {
  *   3. `preview === false` なら `buildPrerenderRoutes` と同じ可視性条件
  *      (published === true かつ published_at が未指定または buildTime 以下) を
  *      満たす記事のみを集計
- *   4. `Date.parse` が NaN を返す不正な日時文字列は除外
+ *   4. `parsePublishedAtMs` が NaN を返す不正な日時文字列は除外
  *   5. 各記事の topics を展開し、同じ tag に属する slug を配列として集約
  *   6. 1 記事内で同じ tag が重複していても slug は 1 回だけ含める
  *   7. タグごとの slug 配列は出現順を維持 (記事列の順序 × topics の順序)
@@ -109,7 +110,7 @@ export function buildTagsIndex(
  * - `published === false` の下書きは常に false
  * - `published_at` 未指定は「公開扱い・予約なし」とみなす
  * - `published_at` が valid な日時で `buildTime` 以下なら true
- * - `Date.parse` が NaN (不正な文字列) なら false (fail-closed)
+ * - `parsePublishedAtMs` が NaN (不正な文字列) なら false (fail-closed)
  */
 function isVisibleAtBuildTime(
   article: TagIndexArticle,
@@ -121,7 +122,7 @@ function isVisibleAtBuildTime(
   if (article.published_at === undefined) {
     return true
   }
-  const publishedAtMs = Date.parse(article.published_at)
+  const publishedAtMs = parsePublishedAtMs(article.published_at)
   if (Number.isNaN(publishedAtMs)) {
     return false
   }


### PR DESCRIPTION
## Summary

close https://github.com/nonz250/homepage/issues/59

`https://nozomi.bike/articles/2026-04-19-ai-rotom-tech/` への直リンが 404
になる事象の修正。当初は OGP の trailing slash と nginx 経路の問題と仮定
していたが、実機検証 (curl 結果と `/articles/` の "まだ記事がありません"
表示) により**そもそも当該記事が production の `.output/public/articles/`
に書き出されていない**ことが判明した。

### 根本原因

`scripts/lib/schema/publishedAt.ts` は `published_at` の 3 形式を受理する
うちの 1 つに Zenn Connect 互換の `YYYY-MM-DD HH:mm` (TZ 情報なし) が含ま
れる。`frontend/utils/prerender/buildPrerenderRoutes.ts` と
`buildTagsIndex.ts` はこの値を `Date.parse` でそのまま ms に変換していた
ため、ホスト OS の TZ に挙動が依存していた。

GitHub Actions ubuntu-latest は UTC で動作するため、`'2026-04-23 21:00'`
が "21:00 UTC" として解釈される。当該記事の意図は "21:00 JST = 12:00 UTC"
だが、build hook 実行時刻 (12:02 UTC) と比較すると 21:00 UTC は未来扱い
となり、prerender 対象から除外されていた (デプロイ済み build の
`prerenderedAt` も実際 `2026-04-23T12:02:13Z` で確認済み)。

## Changes

* `frontend/utils/article/parsePublishedAt.ts` 新設。Zenn Legacy 形式
  (`YYYY-MM-DD HH:mm`) を JST (`+09:00`) として正規化してから `Date.parse`
  に渡し、ISO 8601 with offset / `Z` 付きはそのまま `Date.parse` する純関数。
* `frontend/utils/prerender/buildPrerenderRoutes.ts` の `Date.parse` 呼び
  出しを `parsePublishedAtMs` に置換。
* `frontend/utils/prerender/buildTagsIndex.ts` の同様呼び出しを置換 (個別
  ページの prerender 一覧とタグ index で TZ 解釈を揃え、片方だけ表示される
  歪みを避ける)。
* `frontend/tests/unit/article/parsePublishedAt.test.ts` を新設。CI のホスト
  TZ に依存しない絶対時刻ベースで、Zenn Legacy が常に JST として解釈される
  ことを検証する。
* `frontend/tests/unit/prerender/buildPrerenderRoutes.test.ts` /
  `buildTagsIndex.test.ts` に Issue #59 リグレッションテストを追加
  (`'2026-04-23 21:00'` が UTC build 時刻 13:00 と比較して可視判定されること
  を絶対時刻で固定)。

## Checklist

- [x] `npm run test:unit` (frontend, 593 tests) 全 pass
- [x] `npm run test:integration` (frontend, 30 tests) 全 pass
- [x] `npm run test:contract` (frontend, 55 tests) 全 pass
- [x] `npx vue-tsc --noEmit` typecheck 通過
- [x] CI ホスト TZ に依存しないテストを追加し、リグレッションを固定
- [x] 既存の Zenn Legacy 形式記事を編集せず後方互換を維持

## その他

- `scripts/lib/constants.ts` 側の同等パターン (`PUBLISHED_AT_ZENN_LEGACY_PATTERN`)
  と Regex を独立に持つ構成は既存の duplication パターンに合わせている
  (`frontend/content/schema/article.ts` のヘッダコメントにある「scripts と
  frontend で同期する」方針)。
- root の `tests/integration/realArticles.test.ts` の 1 件失敗は本 PR の
  対象外で、`CLOCK_AFTER` が 2026-04-19 のままで site-articles が 2026-04-23
  公開に rescheduled された結果。stash で本 PR 適用前後とも同じ失敗が再現
  することを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)