### PR TITLE
fix(ci): publish ワークフローの rebase 失敗と Qiita 重複公開を修正

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -201,17 +201,20 @@ jobs:
           # 後続 push に必要。GITHUB_TOKEN は contents: write を持っている。
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Pull latest (defensive rebase)
+        # qiita-publish は自前実行に切り替えたので push は行わないが、並列
+        # push (人手コミット等) が来ても衝突しないよう保険として rebase する。
+        # rebase 失敗時は fail させて人間に委ねる (勝手に上書きしない)。
+        # download-artifact より前に実行する: artifact が articles/ や public/
+        # の tracked file を上書きすると unstaged changes として認識され、
+        # `git pull --rebase` が exit 128 で失敗するため。
+        run: git pull --rebase origin "${GITHUB_REF_NAME}"
+
       - name: Download generated artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: generated
           path: .
-
-      - name: Pull latest (defensive rebase)
-        # qiita-publish は自前実行に切り替えたので push は行わないが、並列
-        # push (人手コミット等) が来ても衝突しないよう保険として rebase する。
-        # rebase 失敗時は fail させて人間に委ねる (勝手に上書きしない)。
-        run: git pull --rebase origin "${GITHUB_REF_NAME}"
 
       - name: Configure git identity
         # github-actions[bot] を commit 主体にする。user.email は GitHub 推奨

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -187,6 +187,24 @@ jobs:
           find public -maxdepth 1 -type f -regextype posix-extended -regex '.*/[a-f0-9]+\.md$' -print -delete || true
           rm -rf public/.remote
 
+      - name: Upload published public/ (with qiita ids written back)
+        # qiita-cli は publish 成功時に レスポンスの記事 ID を public/<slug>.md の
+        # フロントマター `id` フィールドに書き戻す。この変更を auto-commit job に
+        # 受け渡さないと、リポジトリには id 空のまま残り、次回 publish で再び
+        # 新規記事として作成されてしまう (Qiita 上に同一記事が量産される)。
+        # UUID drafts 削除と public/.remote 除去後の状態を artifact 化することで、
+        # 漏洩リスクを避けつつ id 書き戻しのみを永続化する。
+        # if-no-files-found: warn とするのは publish 対象 0 件のレース時に
+        # 致命的 error にしないため (.allowlist が常にあるはずだが保守的に)。
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: published-public
+          path: public/
+          if-no-files-found: warn
+          retention-days: 7
+          # public/.allowlist を含めるため hidden files を許可。
+          include-hidden-files: true
+
   auto-commit:
     name: Commit generated articles diff back to main
     needs: qiita-publish
@@ -215,6 +233,24 @@ jobs:
         with:
           name: generated
           path: .
+
+      - name: Download published public/ (qiita ids)
+        # qiita-publish job が書き戻した id を含む public/ を別ディレクトリに
+        # 一旦展開する。直接 path: public/ にすると download-artifact@v4 の
+        # 同 path への重複展開挙動に依存することになるため、明示的に分離して
+        # 後段の cp で同名ファイル後勝ちを保証する。
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: published-public
+          path: .published-public/
+
+      - name: Overlay qiita-written-back ids onto public/
+        # generated artifact 由来の public/ に qiita-cli が id を書き戻した
+        # public/<slug>.md を上書きする。同名ファイルは published-public 側が
+        # 後勝ち。.published-public ディレクトリは tmp なので即削除する。
+        run: |
+          cp -a .published-public/. public/
+          rm -rf .published-public
 
       - name: Configure git identity
         # github-actions[bot] を commit 主体にする。user.email は GitHub 推奨


### PR DESCRIPTION
## Summary

[failed run #24940212681](https://github.com/nonz250/homepage/actions/runs/24940212681)

`Publish articles` ワークフローで継続的に発生していた 2 つのバグを修正します。

## Changes

### 1. `auto-commit` ジョブの `git pull --rebase` が失敗していた問題

- 原因: `download-artifact` が `articles/` と `public/` の tracked file を上書きし、unstaged changes が発生した状態で `git pull --rebase` が exit 128 で失敗していた。
- 修正: `Pull latest (defensive rebase)` ステップを `Download generated artifacts` の前に移動。設計コメントの「並列push時はfailして人間に委ねる」意図は維持。

### 2. Qiita に同じ記事が新規記事として何度も公開されていた問題

- 原因: qiita-cli は publish 成功時にレスポンスの記事 ID を `public/<slug>.md` のフロントマター `id` に書き戻すが、その変更が `auto-commit` ジョブには反映されず、リポジトリには `id: ''` のまま残っていた。次回 publish 時に再度新規作成され、Qiita 上で同一記事が量産される無限ループになっていた。
- 修正:
  - `qiita-publish` ジョブで UUID drafts 削除後の `public/` を `published-public` artifact として upload。
  - `auto-commit` ジョブで `generated` artifact を展開した後、`published-public` artifact を別ディレクトリ (`.published-public/`) に展開し、`cp -a` で `public/` に後勝ちで上書き。
  - `download-artifact@v4` の同 path 重複展開挙動に依存しない実装にしている。

## Checklist

- [ ] 次回 push で `auto-commit` ジョブが exit 128 で fail しないこと
- [ ] 次回 publish 後、リポジトリの `public/nonz250-ai-rotom.md` のフロントマター `id` が空でない値で commit されること
- [ ] さらに次回の push で Qiita 上に新規記事が作成されず、既存記事の update のみが行われること
- [ ] `published-public` artifact に UUID basename ファイルや `public/.remote/` が含まれていないこと（漏洩防止の二重防御）

## その他

Qiita 上で既に量産されてしまった重複記事は手動で削除する必要があります。修正後、ログを残す `published-public` artifact から id 反映を確認できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)