### PR TITLE
fix(content): Qiita stale id を残存記事に同期

### DIFF
--- a/public/nonz250-ai-rotom.md
+++ b/public/nonz250-ai-rotom.md
@@ -7,7 +7,7 @@ tags:
   - pokemon
 private: false
 updated_at: '2026-04-26T05:55:08+09:00'
-id: bbbdaafca8c268e9c6b8
+id: 9f154dc9bc947266cb82
 organization_url_name: null
 slide: false
 ignorePublish: false


### PR DESCRIPTION
## Summary

PR #66 マージ前の `publish.yml` バグで Qiita 上に同一記事が複数公開されていた問題のフォローアップ。重複記事はユーザー側で手動削除されたが、リポジトリの `public/nonz250-ai-rotom.md` は **削除済みの記事を指す id** をフロントマターに保持しており、次回 publish で `qiita-cli` が存在しない記事への update を試みる不整合状態になっていた。

残存している記事の id にリポジトリ側を合わせ、`qiita-cli` が同一記事への update を継続できるようにする。

## Changes

* `public/nonz250-ai-rotom.md` の `id` を `bbbdaafca8c268e9c6b8` (削除済み) → `9f154dc9bc947266cb82` (残存) に書き換え

## Checklist

- [ ] このマージ後の publish run で `qiita-publish` ジョブが success すること
- [ ] Qiita 上に新規記事が作成されず、`9f154dc9bc947266cb82` の update のみが行われること
- [ ] `auto-commit` で書き戻される `updated_at` が当該 run のタイムスタンプに更新されること

## その他

- 重複公開のループ自体は PR #66 (`fix(ci): persist qiita-cli written-back ids via published-public artifact`) で塞がっており、本 PR が対処するのは「id 書き戻しが最初に永続化された run の対象記事を、ユーザーが事後に削除した」というケース。
- 次に同じ事象 (リポジトリ側 id が指す記事が外側で削除される) が起きた場合の対応手順として運用ノウハウ化しておくと安全。

🤖 Generated with [Claude Code](https://claude.com/claude-code)