### PR TITLE
chore(frontend): ヘッダーから外部 Blog リンクを削除

### DIFF
--- a/frontend/components/TheHeader.vue
+++ b/frontend/components/TheHeader.vue
@@ -15,12 +15,9 @@
         <nuxt-link to="/articles" class="actions-link mr-1">
           Articles
         </nuxt-link>
-        <nuxt-link to="/#contact" class="actions-link mr-1">
+        <nuxt-link to="/#contact" class="actions-link">
           Contact
         </nuxt-link>
-        <anchor link="https://labo.nozomi.bike" :shine="false" class="actions-link">
-          Blog
-        </anchor>
       </div>
       <div class="right" />
     </div>


### PR DESCRIPTION
## Summary

ヘッダー右側に常設されていた外部 Blog リンク (`https://labo.nozomi.bike`) を撤去する。ユーザー要望によるシンプルな UI 整理。

## Changes

* `frontend/components/TheHeader.vue` から `Blog` の `<anchor>` 要素を削除
* 末尾に取り残された `Contact` リンクの class から `mr-1` を削除し、「最後尾要素は right margin を持たない」既存パターンを維持

## Checklist

- [ ] PC / スマホでヘッダーを表示し、Blog リンクが消えていること
- [ ] Articles の右側マージンと Contact の表示位置が崩れていないこと
- [ ] スクロール後の小型ヘッダー (`scrolling-actions`) には影響が無いこと

## その他

`Anchor` コンポーネント自体は同ファイル内の GitHub アイコン側で引き続き利用するため、import は残置している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)