### PR TITLE
ci(workflows): add concurrency to cancel stale runs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,14 @@ on:
 permissions:
   contents: read
 
+# 手動連打で deploy が二重起動すると rsync が同一ホストに重なり、
+# 本番側のファイルが中途半端な state になる恐れがある。直列化のみ
+# 行い、進行中の deploy は最後まで走らせる (cancel-in-progress: false)。
+# publish.yml と同じ「副作用ありの job は cancel しない」方針。
+concurrency:
+  group: deploy-manual-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,19 @@ on:
 permissions:
   contents: read
 
+# 同一 ref への連続 push があった場合、進行中の test run を kill して
+# 最新 push のみを評価する。CI 副作用は同一 run 内の artifact / nginx
+# コンテナで完結し ephemeral runner で破棄されるため、cancel しても
+# 外部状態は壊れない (publish.yml のような外部 API publish はここに
+# 含まれない)。
+# - PR push: github.ref = refs/pull/<n>/merge で PR ごとに独立。
+#   別 PR を巻き添えキャンセルしない。
+# - main push: github.ref = refs/heads/main で main 上の連続マージを
+#   最新だけ走らせる。
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

同一 ref への連続 push があった場合に古い CI run を kill して最新 push のみを評価するための concurrency 設定を追加する。

## Changes

- **`.github/workflows/test.yml`**: `concurrency: { group: test-${{ github.ref }}, cancel-in-progress: true }` を追加。CI 副作用は同一 run 内の artifact / nginx コンテナで完結し ephemeral runner で破棄されるため、cancel しても外部状態は壊れない。
- **`.github/workflows/deploy.yml`**: `concurrency: { group: deploy-manual-${{ github.ref }}, cancel-in-progress: false }` を追加。手動連打で deploy が二重起動して rsync が衝突するのを防ぐが、cancel すると本番側のファイルが中途半端になるため直列化のみとする。
- **`.github/workflows/publish.yml`**: 変更なし。Qiita 公開の整合性を優先するため既存の `cancel-in-progress: false` を維持。

## 設計判断

| ファイル | cancel-in-progress | 理由 |
|---|---|---|
| test.yml | `true` | 副作用なし、最新 push のみ評価で十分 |
| deploy.yml | `false` | rsync 中断による本番破損リスク |
| publish.yml | `false`（既存維持）| Qiita publish の途中状態が永続化するリスク |

## 挙動

- PR push: `github.ref = refs/pull/<n>/merge` で PR ごとに独立。別 PR を巻き添えキャンセルしない。
- main push: `github.ref = refs/heads/main` で main 上の連続マージを最新だけ走らせる。

## Checklist

- [x] architect / test-engineer / code-reviewer / security-engineer の設計レビュー通過
- [x] code-reviewer / security-engineer の最終レビュー通過 (両者「承認」)
- [x] YAML パース確認済み
- [ ] 実 push でキャンセル挙動を観察 (このブランチでの連続 push でも確認可)

## その他

`group` キーは `prefix-${{ github.ref }}` 形式で publish.yml と一貫性を取った。`group` キーには GitHub 管理コンテキスト (`github.ref`) のみを展開しており、expression injection の経路は持たない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)