### PR TITLE
fix(articles): ヘディングの自動アンカーをタイトル風スタイルに

### DIFF
--- a/frontend/assets/scss/_typography.scss
+++ b/frontend/assets/scss/_typography.scss
@@ -30,3 +30,9 @@ $article-heading-line-height: 1.4;
 // h2 のみ下線を引いて章区切りを強調する。色は本文と同じく低彩度で抑える。
 $article-heading-h2-border-color: rgba(0, 0, 0, 0.08);
 $article-heading-h2-padding-bottom: 0.3rem;
+
+// MDC が h2〜h6 内側に挿入する自動アンカー (`<a href="#id">`) を、
+// 通常状態ではタイトル相当に同化させ、ホバー時のみ控えめに
+// リンク性を示すための token。色は本文側で `inherit` させるため
+// ここでは hover 時のオフセットだけを集約する。
+$article-heading-anchor-hover-underline-offset: 0.2em;

--- a/frontend/pages/articles/[...slug].vue
+++ b/frontend/pages/articles/[...slug].vue
@@ -147,6 +147,25 @@ useSeoMeta({
     scroll-margin-top: var(--header-height);
   }
 
+  // MDC (`@nuxt/content` v3) は h2〜h6 内側に `<a href="#id">` を自動挿入し、
+  // TOC からのジャンプを成立させる。既定だとブラウザのリンク色 (青系・下線) が
+  // 出てしまい「見出しがリンクのまま」に見えるので、親ヘディングのスタイルを
+  // そのまま継承させ、ホバー時のみ控えめにリンク性を示す。
+  :deep(h2 a),
+  :deep(h3 a),
+  :deep(h4 a),
+  :deep(h5 a),
+  :deep(h6 a) {
+    color: inherit;
+    font-weight: inherit;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+      text-underline-offset: typography.$article-heading-anchor-hover-underline-offset;
+    }
+  }
+
   :deep(h2) {
     margin-top: typography.$article-heading-margin-top-h2;
     padding-bottom: typography.$article-heading-h2-padding-bottom;


### PR DESCRIPTION
## Summary

close https://github.com/nonz250/homepage/issues/67

`@nuxt/content` v3 の MDC は h2〜h6 内側に `<a href=\"#id\">` を自動挿入し
TOC からのジャンプを成立させているが、既定だとブラウザのリンク色
(青系・下線) のままで「見出しがリンクのまま」に見えていた問題を修正する。

## Changes

* `frontend/pages/articles/[...slug].vue` の scoped style に `:deep(h2 a)`〜`:deep(h6 a)` のルールを追加し、`color: inherit / font-weight: inherit / text-decoration: none` で親ヘディングに同化させる。ホバー時のみ控えめに `underline` を付与し、TOC アンカーとしての機能とアフォーダンスは維持する。
* `frontend/assets/scss/_typography.scss` に `$article-heading-anchor-hover-underline-offset` token を追加し、マジックナンバーを集約する。

## Checklist

- [x] 既存 unit / integration / contract テストがすべて通ること (54 + 4 + 3 file passed)
- [x] `_typography.scss` の token としてマジックナンバーを集約
- [x] TOC アンカーリンク (`#id` ジャンプ) の機能は維持
- [ ] 実機 (Playwright / 目視) で h2〜h6 がリンク色ではなく本文色で表示されることを確認

## その他

- ダークモードは未対応のため考慮対象外。
- レスポンシブ (`@media max-width: 600px`) 側のスタイルは触らず、サイズ変更のみで色には影響しない既存挙動を踏襲。

🤖 Generated with [Claude Code](https://claude.com/claude-code)