### PR TITLE
fix(articles): Slack で記事 OGP 画像が表示されない問題を修正

### DIFF
--- a/frontend/pages/articles/[...slug].vue
+++ b/frontend/pages/articles/[...slug].vue
@@ -21,6 +21,8 @@ import {
   type TocLink,
 } from '~/utils/article/flattenTocLinks'
 import { resolveArticleOgImagePath } from '~/constants/seo'
+import { normalizeMetaContent } from '~/utils/seo/normalizeMetaContent'
+import { OGP_WIDTH, OGP_HEIGHT } from '~/utils/ogp/ogpTemplate'
 
 const route = useRoute()
 // `[...slug]` は配列で渡る可能性があるため文字列に正規化。
@@ -65,10 +67,15 @@ const tocHeadings: FlatTocHeading[] = flattenTocLinks(
   articleContent.toc?.links,
 )
 const isDraft = preview && !article.published
-const description: string =
-  typeof articleContent.description === 'string' && articleContent.description
+// `articleContent.description` は Nuxt Content が本文先頭段落から auto-generate
+// するため改行を含む。`<meta>` の属性値に載せる前に半角スペース 1 つへ正規化する。
+const fallbackDescription = `${article.title} | Nozomi Hosaka`
+const rawDescription: string =
+  typeof articleContent.description === 'string'
     ? articleContent.description
-    : `${article.title} | Nozomi Hosaka`
+    : ''
+const description: string =
+  normalizeMetaContent(rawDescription) || fallbackDescription
 
 // 記事個別の Open Graph / SEO メタを組み立てる。
 // baseUrl は runtimeConfig.public に置かれており、クライアント側からも
@@ -89,6 +96,10 @@ const ogImageUrl: string = `${baseUrl}${resolveArticleOgImagePath(slug)}`
 useHead({
   title: `${article.title} - Nozomi Hosaka`,
 })
+// og:image の補助メタ (width / height / type / alt) を明示する。Slack の
+// link unfurling は画像サイズ情報がない `summary_large_image` で取りこぼしが
+// 起きるという報告が経験的にあるため、Satori 生成側の OGP_WIDTH / OGP_HEIGHT
+// と同じ値をそのまま載せる (二重定義による不整合を避ける意図でも定数を再利用)。
 useSeoMeta({
   description,
   ogType: 'article',
@@ -96,6 +107,10 @@ useSeoMeta({
   ogDescription: description,
   ogUrl: canonicalUrl,
   ogImage: ogImageUrl,
+  ogImageType: 'image/png',
+  ogImageWidth: OGP_WIDTH,
+  ogImageHeight: OGP_HEIGHT,
+  ogImageAlt: article.title,
 })
 </script>
 

--- a/frontend/tests/unit/seo/normalizeMetaContent.test.ts
+++ b/frontend/tests/unit/seo/normalizeMetaContent.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeMetaContent } from '~/utils/seo/normalizeMetaContent'
+
+describe('normalizeMetaContent', () => {
+  it('改行を半角スペースに置換する', () => {
+    expect(normalizeMetaContent('一行目\n二行目')).toBe('一行目 二行目')
+  })
+
+  it('CRLF も半角スペースに置換する', () => {
+    expect(normalizeMetaContent('一行目\r\n二行目')).toBe('一行目 二行目')
+  })
+
+  it('連続する空白を 1 つに圧縮する', () => {
+    expect(normalizeMetaContent('a   b\t\tc\n\nd')).toBe('a b c d')
+  })
+
+  it('両端の空白を取り除く', () => {
+    expect(normalizeMetaContent('  abc  ')).toBe('abc')
+  })
+
+  it('空文字列はそのまま返す', () => {
+    expect(normalizeMetaContent('')).toBe('')
+  })
+
+  it('空白だけの文字列は空文字列に正規化される', () => {
+    expect(normalizeMetaContent('   \n\t  ')).toBe('')
+  })
+
+  it('改行を含まない通常の文字列はそのまま返す', () => {
+    expect(normalizeMetaContent('普通の説明文')).toBe('普通の説明文')
+  })
+})

--- a/frontend/utils/seo/normalizeMetaContent.ts
+++ b/frontend/utils/seo/normalizeMetaContent.ts
@@ -1,0 +1,17 @@
+/**
+ * `<meta>` の `content` 属性に入れる文字列を正規化する純関数。
+ *
+ * 記事の `description` は Nuxt Content が本文先頭段落から auto-generate する
+ * ため改行・連続スペースを含み得る。HTML5 仕様上は属性値内の改行は valid
+ * だが、外部 OGP パーサ (Slack の link unfurling 等) の挙動を整える防御的な
+ * 正規化として、SNS に出る文字列をデバッガで確認しやすくする目的も兼ねる。
+ *
+ * - 全種類の連続空白 (改行・タブ・複数スペース) を半角スペース 1 つに圧縮
+ * - 両端の空白を除去
+ *
+ * 受け取った文字列が結果的に空になった場合は空文字列を返す。呼び出し側で
+ * fallback 文字列に差し替える責務を持つ。
+ */
+export function normalizeMetaContent(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}


### PR DESCRIPTION
## Summary

記事ページの URL を Slack に貼り付けても OGP 画像 (`/ogp/<slug>.png`) がリンクプレビューに表示されない問題への対応。

## 原因 (確度の高い順)

- **`og:image:width` / `og:image:height` 未指定**: Slack の link unfurling は `summary_large_image` で画像サイズ情報が無いと、画像取得・サイズ判定フェーズで諦めることがある。これが本命の原因と推定
- **`og:description` / `description` に改行が混入**: Nuxt Content `type: 'page'` が本文先頭段落から description を auto-generate するため、HTML 属性値内に `\n` が残っていた。HTML5 仕様上は valid だが、外部 OGP パーサの挙動を整える防御として正規化を入れる

og:image URL 自体は HTTPS 200 / `image/png` / 1200x630 / 31KB で問題なし。

## Changes

- `frontend/utils/seo/normalizeMetaContent.ts` を新規追加 (連続空白を半角スペース 1 つに圧縮し両端 trim する純関数)
- 記事個別ページ (`frontend/pages/articles/[...slug].vue`) で description を `normalizeMetaContent` 経由に
- 同ページの `useSeoMeta` に `ogImageType` / `ogImageWidth` / `ogImageHeight` / `ogImageAlt` を追加。`OGP_WIDTH` / `OGP_HEIGHT` は Satori 生成側 (`utils/ogp/ogpTemplate.ts`) の既存定数を再利用して二重定義を避ける

## 動作確認

- `frontend` の全 685 ユニットテストパス
- `npm run generate` で出力された `.output/public/articles/2026-04-19-ai-rotom-tech/index.html` を検証し、`og:description` の改行が半角スペースに正規化され、`og:image:width="1200"` / `og:image:height="630"` / `og:image:type="image/png"` / `og:image:alt` の 4 行が新たに出力されることを確認

## Checklist

- [x] `frontend` ユニットテストすべてパス
- [x] `nuxt generate` で記事ページの HTML を生成し、og タグの内容を目視確認
- [ ] デプロイ後、本番の記事 URL を Slack に貼って unfurl 結果を確認 (キャッシュ済み URL は `chat.unfurl` 等で再取得が必要)

## その他

- 修正対象は記事個別ページのみ。トップページや記事一覧ページの `og:image` (`nuxt.config.ts` 内のデフォルト) は webp で width/height が無い状態だが、本 PR のスコープ外とする
- code-reviewer のレビュー (Must なし、Should 反映済み) を通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)