### PR TITLE
ci(publish): auto-commit を deploy key 経由に切り替え

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,16 @@
 #                   publish 直後に sync で pull された UUID basename と
 #                   public/.remote/ を明示削除し、限定共有記事の漏洩を遮断。
 # - auto-commit   : generate job が作った articles/ と public/ の差分を
-#                   [skip ci] 付きで push する。GITHUB_TOKEN での push は
-#                   他ワークフローを起動しない (GitHub 仕様) ため、本ワーク
-#                   フロー自身の paths トリガと併せて二重に自己ループを防ぐ。
+#                   [skip ci] 付きで push する。main の branch ruleset
+#                   (pull_request 必須) を bypass するため、リポジトリ専用
+#                   Deploy key (write 権限つき、ruleset の bypass actors に
+#                   `actor_type: DeployKey` で登録) で SSH push する。
+#                   Deploy key の push は GITHUB_TOKEN と違って他ワークフロー
+#                   を起動する仕様だが、test.yml と publish.yml 自身は paths
+#                   allowlist で articles/ と public/ を除外しており、
+#                   deploy.yml は workflow_dispatch 専用なので、誤起動と
+#                   自己ループはいずれも paths と [skip ci] の二重防御で
+#                   抑えられる。
 # - deploy        : rsync + ssh で本番 nginx に静的生成物を配布する。
 #                   deploy.yml はバックアップ (workflow_dispatch) として残す。
 #
@@ -216,8 +223,12 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          # 後続 push に必要。GITHUB_TOKEN は contents: write を持っている。
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # main の branch ruleset (pull_request 必須) を bypass するため、
+          # GITHUB_TOKEN ではなくリポジトリ専用 Deploy key (write 権限つき) で
+          # SSH push する。`actions/checkout` の `ssh-key` パラメータは SSH agent
+          # を立てて origin を git@github.com 経路に書き換えるため、後続の
+          # `git pull --rebase` と `git push` がそのまま SSH 経由で走る。
+          ssh-key: ${{ secrets.AUTO_COMMIT_DEPLOY_KEY }}
 
       - name: Pull latest (defensive rebase)
         # qiita-publish は自前実行に切り替えたので push は行わないが、並列


### PR DESCRIPTION
## Summary

main の branch ruleset が「pull_request 必須」化されて以降、`Publish articles` ワークフローの `auto-commit` ジョブが GITHUB_TOKEN で main に直接 push しようとして remote rejected され、後続の `deploy` ジョブまで届かなくなっていた。GitHub Actions integration は個人リポジトリの ruleset bypass actors に追加できないため (`422 Validation Failed`)、リポジトリ専用 Deploy key を write 権限で発行し、ruleset の bypass actors に `actor_type: DeployKey` を登録した上で、auto-commit ジョブの checkout を `ssh-key` 経由に切り替える。

## Changes

- `actions/checkout` に `ssh-key: ${{ secrets.AUTO_COMMIT_DEPLOY_KEY }}` を渡し、後続の `git pull --rebase` / `git push` が SSH 経路 (Deploy key) で走るようにする
- 冒頭コメントを現状の挙動に合わせて更新 (Deploy key push は他ワークフローを起動し得るが、`test.yml` と `publish.yml` 自身の `paths` allowlist が `articles/` と `public/` を除外しているため誤起動と自己ループは抑えられている。`deploy.yml` は `workflow_dispatch` 専用)

## 事前準備 (リポジトリ設定)

- ED25519 SSH 鍵を生成
- 公開鍵を `nonz250/homepage` の Deploy keys に `auto-commit-bot` の title で write 権限つきで登録 (id: `152320430`)
- 秘密鍵を Actions secrets `AUTO_COMMIT_DEPLOY_KEY` に登録
- ruleset `main` (id: 5519661) の bypass actors に `actor_type: DeployKey` / `bypass_mode: always` を追加

## Checklist

- [x] Deploy key 登録 (write 権限つき)
- [x] secret `AUTO_COMMIT_DEPLOY_KEY` 登録
- [x] ruleset bypass actors に DeployKey 追加
- [ ] マージ後、失敗していた publish run (26317001725) を re-run して通ることを確認
- [ ] auto-commit による push が test.yml を起動していないことを確認

## その他

`AUTO_COMMIT_DEPLOY_KEY` には期限がないので、ローテーション運用は人手で行う (年 1 回程度を推奨)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)