### PR TITLE
fix(articles): make slack unfurl render article OGP image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,6 +181,12 @@ jobs:
       - name: Assert no external images in build output
         working-directory: ${{ github.workspace }}
         run: bash scripts/assert-no-external-images.sh
+      # Slack の Link Expanding は head 先頭 8KB しか fetch しないため、
+      # 記事ページの OGP meta が `<style>` より前 & 先頭 8KB 以内に出ているか
+      # を generate 産物に対して直接検証する。`integration` job は generate
+      # に非依存なので、ここで artifact upload 前に同 runner で済ませる。
+      - name: Assert slack unfurl head order
+        run: npx vitest run tests/integration/prerender/articleSlackUnfurlOrder.test.ts
       - name: Upload generated public/
         uses: actions/upload-artifact@v4
         with:

--- a/frontend/pages/articles/[...slug].vue
+++ b/frontend/pages/articles/[...slug].vue
@@ -77,14 +77,9 @@ const rawDescription: string =
 const description: string =
   normalizeMetaContent(rawDescription) || fallbackDescription
 
-// 記事個別の Open Graph / SEO メタを組み立てる。
-// baseUrl は runtimeConfig.public に置かれており、クライアント側からも
-// 参照できる (prerender 時にも展開済み)。記事 URL は `/articles/<slug>` に
-// そろえる。
-// OG 画像は Phase 4 Batch B から記事単位で切り替える。
-// `nitro:build:public-assets` hook で `.output/public/ogp/<slug>.png` を
-// 生成し、ここから `/ogp/<slug>.png` として参照する。slug が予想外の値でも
-// fallback に倒すガードが `resolveArticleOgImagePath` 内に入っている。
+// OG 画像は `nitro:build:public-assets` hook で `.output/public/ogp/<slug>.png`
+// を生成し `/ogp/<slug>.png` として参照する。`resolveArticleOgImagePath` が
+// slug 異常時の fallback を内包する。
 const runtimeConfig = useRuntimeConfig()
 const baseUrl: string = runtimeConfig.public.baseUrl
 // 末尾スラッシュ付きに揃える。nginx 側で `/articles/<slug>` → `/articles/<slug>/`
@@ -96,21 +91,25 @@ const ogImageUrl: string = `${baseUrl}${resolveArticleOgImagePath(slug)}`
 useHead({
   title: `${article.title} - Nozomi Hosaka`,
 })
-// og:image の補助メタ (width / height / type / alt) を明示する。Slack の
-// link unfurling は画像サイズ情報がない `summary_large_image` で取りこぼしが
-// 起きるという報告が経験的にあるため、Satori 生成側の OGP_WIDTH / OGP_HEIGHT
-// と同じ値をそのまま載せる (二重定義による不整合を避ける意図でも定数を再利用)。
-useSeoMeta({
-  description,
-  ogType: 'article',
-  ogTitle: article.title,
-  ogDescription: description,
-  ogUrl: canonicalUrl,
-  ogImage: ogImageUrl,
-  ogImageType: 'image/png',
-  ogImageWidth: OGP_WIDTH,
-  ogImageHeight: OGP_HEIGHT,
-  ogImageAlt: article.title,
+// Slack の Link Expanding は HTTP Range で head 先頭しか fetch しないため、
+// unfurl 判定に必須のタグを <style> より前へ押し上げる。Unhead v2 の
+// `tagPriority: 'critical'` (= 2) は Capo.js のソート規則で同期 stylesheets
+// より後ろに置かれるため、数値で直接負値を指定して確実に前へ出す。
+const PRE_STYLE_PRIORITY = -8
+useHead({
+  meta: [
+    { property: 'og:title', content: article.title, tagPriority: PRE_STYLE_PRIORITY },
+    { property: 'og:image', content: ogImageUrl, tagPriority: PRE_STYLE_PRIORITY },
+    { property: 'og:description', content: description, tagPriority: PRE_STYLE_PRIORITY },
+    { property: 'og:url', content: canonicalUrl, tagPriority: PRE_STYLE_PRIORITY },
+    { property: 'og:type', content: 'article', tagPriority: PRE_STYLE_PRIORITY },
+    { name: 'twitter:image', content: ogImageUrl, tagPriority: PRE_STYLE_PRIORITY },
+    { name: 'description', content: description, tagPriority: PRE_STYLE_PRIORITY },
+    { property: 'og:image:type', content: 'image/png' },
+    { property: 'og:image:width', content: String(OGP_WIDTH) },
+    { property: 'og:image:height', content: String(OGP_HEIGHT) },
+    { property: 'og:image:alt', content: article.title },
+  ],
 })
 </script>
 

--- a/frontend/tests/integration/prerender/articleSlackUnfurlOrder.test.ts
+++ b/frontend/tests/integration/prerender/articleSlackUnfurlOrder.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+/**
+ * Slack の Link Expanding は `Range: bytes=0-N` で head の先頭しか fetch しない
+ * ため、og:image をはじめとする unfurl 必須 meta が「先頭 8KB 以内」かつ
+ * 「最初の `<style>` より前」に出ていることをジェネレート済み HTML に対して
+ * 直接検証する。記事ページの head 順序が崩れて Slack 上のカード表示が
+ * 戻ってしまう回帰を防ぐ目的。
+ *
+ * `npm run generate` の産物 (`.output/public/...`) が存在しない環境
+ * (CI の generate 未実行ジョブ / `npm run test:integration` だけ叩いた状態)
+ * では assertion を回せないため、ファイルが無い場合は describe 自体を
+ * skip する。CI 上は `generate` job 内で本テストを明示的に走らせる。
+ */
+
+const REPO_ROOT_FROM_THIS_FILE = '../../..'
+const GENERATED_HTML_PATH = resolve(
+  __dirname,
+  REPO_ROOT_FROM_THIS_FILE,
+  '.output/public/articles/2026-04-19-ai-rotom-tech/index.html',
+)
+
+// Slack Link Expanding が一度に取りに行く head 先頭のサイズ。実測値ではなく
+// 「この範囲に必須メタが収まっていれば Slack の unfurl が成立する」と判定
+// するための上限値。8KB を超えた瞬間にカードが出なくなる兆候を検知する。
+const SLACK_UNFURL_HEAD_BUDGET_BYTES = 8 * 1024
+
+// 必須 OGP meta タグの substring。Slack / Twitter / 一般 OG クローラが
+// unfurl 判定に使うコアセットに限定する。補助メタ (og:image:width 等) は
+// 末尾でも構わないため対象外。
+const CRITICAL_META_FRAGMENTS = [
+  'property="og:title"',
+  'property="og:image"',
+  'property="og:description"',
+  'property="og:url"',
+  'property="og:type"',
+  'name="twitter:image"',
+  'name="description"',
+] as const
+
+// 本テストはローカル開発時の `npm run test:integration` でも壊れずに走らせ
+// たいため、generate 産物が無い環境では skip する。CI 側は generate job
+// 内で必ず本テストを呼び出すため、回帰検知漏れは起きない。
+const generatedHtmlExists = existsSync(GENERATED_HTML_PATH)
+
+describe.skipIf(!generatedHtmlExists)(
+  'article page slack unfurl head order (integration)',
+  () => {
+    const html = generatedHtmlExists
+      ? readFileSync(GENERATED_HTML_PATH, 'utf-8')
+      : ''
+    const headEndIndex = html.indexOf('</head>')
+    const head = html.slice(0, headEndIndex)
+    const firstStyleIndex = head.indexOf('<style')
+
+    it('places og:image before the first <style> tag', () => {
+      const ogImageIndex = head.indexOf('property="og:image"')
+      expect(ogImageIndex).toBeGreaterThanOrEqual(0)
+      expect(firstStyleIndex).toBeGreaterThanOrEqual(0)
+      expect(ogImageIndex).toBeLessThan(firstStyleIndex)
+    })
+
+    it('places every critical OGP meta tag before the first <style>', () => {
+      for (const fragment of CRITICAL_META_FRAGMENTS) {
+        const index = head.indexOf(fragment)
+        expect(
+          index,
+          `${fragment} should appear in <head>`,
+        ).toBeGreaterThanOrEqual(0)
+        expect(
+          index,
+          `${fragment} should appear before the first <style>`,
+        ).toBeLessThan(firstStyleIndex)
+      }
+    })
+
+    it('fits every critical OGP meta tag within the slack unfurl byte budget', () => {
+      const headPrefix = head.slice(0, SLACK_UNFURL_HEAD_BUDGET_BYTES)
+      for (const fragment of CRITICAL_META_FRAGMENTS) {
+        expect(
+          headPrefix.includes(fragment),
+          `${fragment} should appear within the first ${SLACK_UNFURL_HEAD_BUDGET_BYTES} bytes of <head>`,
+        ).toBe(true)
+      }
+    })
+
+    it('emits og:image and og:url as absolute URLs under the production baseUrl', () => {
+      // baseUrl は本番値をテスト内に直書きする。`nuxt.config.ts` の runtimeConfig
+      // と乖離した場合にもここで検知したい (Slack はリダイレクト後の絶対 URL を
+      // canonical と一致させない限り unfurl を失敗させる)。
+      const expectedBaseUrl = 'https://nozomi.bike'
+      const ogImageMatch = head.match(/property="og:image" content="([^"]+)"/)
+      const ogUrlMatch = head.match(/property="og:url" content="([^"]+)"/)
+      expect(ogImageMatch?.[1]).toMatch(
+        new RegExp(`^${expectedBaseUrl}/ogp/.+\\.png$`),
+      )
+      expect(ogUrlMatch?.[1]).toMatch(
+        new RegExp(`^${expectedBaseUrl}/articles/.+/$`),
+      )
+    })
+  },
+)


### PR DESCRIPTION
## Summary

記事ページのリンクを Slack に貼っても OGP 画像カードが表示されない不具合の修正。Slack の `Slackbot-LinkExpanding` は HTTP Range で head 先頭しか fetch しない仕様 ([api.slack.com/robots](https://api.slack.com/robots)) だが、Nuxt SFC の scoped style が head に大量にインライン化された結果、og:image 系メタタグが head の 55KB 目以降まで押し下げられ、unfurl 判定に到達できていなかった。

## Changes

* `frontend/pages/articles/[...slug].vue`: `useSeoMeta` を `useHead({ meta: [...] })` に置換し、Slack が unfurl 判定で読む必須タグに `tagPriority: -8` を付与して `<style>` より前に押し上げる。あわせて `twitter:image` も追加。
* `frontend/tests/integration/prerender/articleSlackUnfurlOrder.test.ts`: 生成 HTML を直接読み、必須メタが `<style>` より前かつ先頭 8KB 以内に出ているかを検証する統合テストを追加。
* `.github/workflows/test.yml`: `generate` job の artifact upload 直前に上記テストを 1 step 挿入し、回帰時には fail-closed で後段の e2e/security-test に伝播させない。

## 動作確認

ローカルで `npm run generate` 実行後、`.output/public/articles/2026-04-19-ai-rotom-tech/index.html` を計測:

| 指標 | byte position |
| --- | --- |
| og:image | 296 |
| 最初の `<style>` | 1288 |
| head 全体 | 56039 |

og:image が `<style>` より前に出るようになり、Slack の Range fetch 範囲 (先頭 8KB) 内に必須メタが全て収まる。

既存テストは `test:unit` 600 / `test:integration` 30 (+新規 4) / `test:contract` 55 すべて PASS。

## Checklist

- [ ] デプロイ後、Slack 自分宛 DM に記事 URL を投稿して unfurl 表示が出ることを確認 (Slack キャッシュ TTL 約 30 分のため過去キャッシュが残っている場合は URL に query string を付けて回避)
- [ ] 既存記事一覧/タグページの OGP 表示 (デフォルト OGP 画像) に副作用が出ていないか確認

## その他

`tagPriority` に `'critical'` ではなく数値 `-8` を採用した理由: Unhead v2 で `'critical'` が値 2 にマップされ、Capo.js のソート規則で同期 stylesheets (weight 0) より後ろに置かれてしまうため (`unjs/unhead#693`, `nuxt/nuxt#33837`)。

スコープ外 (フォローアップ候補):

* 記事一覧 / タグページ / `app.head` defaults も同じ priority 調整が必要か (`/articles` `/articles/topics/<tag>` を Slack で確認後)
* `frontend/nuxt.config.ts` の SFC scoped style インライン化 (`features.inlineStyles`) の見直し (head 肥大の根治)
* レビューで指摘された Nit (テストの固定 slug 依存, baseUrl 直書き)


🤖 Generated with [Claude Code](https://claude.com/claude-code)